### PR TITLE
Linux CPU usage calculation change

### DIFF
--- a/lib/class.OS_Linux.php
+++ b/lib/class.OS_Linux.php
@@ -1597,6 +1597,12 @@ class OS_Linux extends OS_Unix_Common {
 		 if (!empty($this->settings['timer']))
 			 $t = new LinfoTimerStart('Determining CPU usage');
 
+		 //Show overall cpu usage 
+		 $this->cpu_percent['overall'] = exec("top -bn 1 | awk '{print $9}' | tail -n +8 | awk '{s+=$1} END {print s}'");
+		 
+		 /*
+		 //Commented to prevent sleep(1) who add 1 sec to script execution
+		 //This way show cpu usage for each procs
 		 $iterations = 2;
 
 		 // Probably only inline function here. Only used once so it makes sense.
@@ -1624,6 +1630,7 @@ class OS_Linux extends OS_Unix_Common {
 			 if ($iterations > 1 && $i != $iterations - 1)
 				 sleep(1);
 		 }
+		 */
 	 }
 
 	/**


### PR DESCRIPTION
prevent sleep(1)

use for : https://github.com/jrgp/linfo/issues/15

this fix prevent from sleep 1 but display only overall CPU usage, not for each one
i kept in comments old codes

Btw the fix made the calculation in 0.2 sec on my i7 comp (that s still better than 1 sec but not perfect ...)

i've checked, the sleep is set to 1 sec, and it has to be set to have /proc stat refreshed to get cpu %.
i didn't found another way to get cpu % with pure php, 

Btw Keeo posted solution, will draw numbers that can't be undertood by users, so i don't think it is a correct fix.
