### PR TITLE
settings via constructor

### DIFF
--- a/lib/class.Linfo.php
+++ b/lib/class.Linfo.php
@@ -42,7 +42,7 @@ class Linfo {
 		$version = '',
 		$time_start = 0;
 
-	public function __construct(array $settings = []) {
+	public function __construct($settings = array()) {
 
 		// Time us
 		$this->time_start = microtime(true);
@@ -281,7 +281,7 @@ class Linfo {
 		$this->runExtensions();
 	}
 
-	protected function loadSettings(array $settings = []) {
+	protected function loadSettings($settings = array()) {
 
 		// Running unit tests?
 		if (defined('LINFO_TESTING')) {
@@ -291,7 +291,7 @@ class Linfo {
 			return;
 		}
 
-		if(empty($settings)) {
+		if(!$settings) {
 			// If configuration file does not exist but the sample does, say so
 			if (!is_file(LINFO_LOCAL_PATH . 'config.inc.php') && is_file(LINFO_LOCAL_PATH . 'sample.config.inc.php'))
 				throw new LinfoFatalException('Make changes to sample.config.inc.php then rename as config.inc.php');

--- a/lib/class.Linfo.php
+++ b/lib/class.Linfo.php
@@ -382,19 +382,8 @@ class Linfo {
 	 *
 	 * Returning reference so extensions can modify result
 	 */
-	public function &getInfo($filtered = false) {
-		if($filtered) {
-			$info = array_filter($this->info, function($item) {
-				if($item === '' || $item === [] || $item === false) {
-					return false;
-				} else {
-					return true;
-				}
-			});
-			return $info;
-		} else {
-			return $this->info;
-		}
+	public function &getInfo() {
+		return $this->info;
 	}
 
 	/*

--- a/lib/class.Linfo.php
+++ b/lib/class.Linfo.php
@@ -42,7 +42,7 @@ class Linfo {
 		$version = '',
 		$time_start = 0;
 
-	public function __construct() {
+	public function __construct(array $settings = []) {
 
 		// Time us
 		$this->time_start = microtime(true);
@@ -60,7 +60,7 @@ class Linfo {
 			@ini_set('date.timezone', 'Etc/UTC');
 
 		// Load our settings/language
-		$this->loadSettings();
+		$this->loadSettings($settings);
 		$this->loadLanguage();
 		
 		// Some classes need our vars; config them
@@ -281,7 +281,7 @@ class Linfo {
 		$this->runExtensions();
 	}
 
-	protected function loadSettings() {
+	protected function loadSettings(array $settings = []) {
 
 		// Running unit tests?
 		if (defined('LINFO_TESTING')) {
@@ -291,16 +291,18 @@ class Linfo {
 			return;
 		}
 
-		// If configuration file does not exist but the sample does, say so
-		if (!is_file(LINFO_LOCAL_PATH . 'config.inc.php') && is_file(LINFO_LOCAL_PATH . 'sample.config.inc.php'))
-			throw new LinfoFatalException('Make changes to sample.config.inc.php then rename as config.inc.php');
-
-		// If the config file is just gone, also say so
-		elseif(!is_file(LINFO_LOCAL_PATH . 'config.inc.php'))
-			throw new LinfoFatalException('Config file not found.');
-
-		// It exists; load it
-		$settings = LinfoCommon::getVarFromFile(LINFO_LOCAL_PATH . 'config.inc.php', 'settings');
+		if(empty($settings)) {
+			// If configuration file does not exist but the sample does, say so
+			if (!is_file(LINFO_LOCAL_PATH . 'config.inc.php') && is_file(LINFO_LOCAL_PATH . 'sample.config.inc.php'))
+				throw new LinfoFatalException('Make changes to sample.config.inc.php then rename as config.inc.php');
+	
+			// If the config file is just gone, also say so
+			elseif(!is_file(LINFO_LOCAL_PATH . 'config.inc.php'))
+				throw new LinfoFatalException('Config file not found.');
+	
+			// It exists; load it
+			$settings = LinfoCommon::getVarFromFile(LINFO_LOCAL_PATH . 'config.inc.php', 'settings');
+		}
 
 		// Don't just blindly assume we have the ob_* functions...
 		if (!function_exists('ob_start'))


### PR DESCRIPTION
allow to give an array of settings via the constructor.

possible settings file:
```php
<?php
return [
    'byte_notation' => 1024,
    'dates' => 'm/d/y h:i A (T)',
    'language' => 'en',
    'icons' => true,
    'theme' => 'default',
    'cpu_usage' => true,

    'show' => [
        'kernel' => true,
        'os' => true,
        'load' => true,
        'ram' => true,
        'hd' => true,
        'mounts' => true,
        'mounts_options' => true,
        'network' => true,
        'uptime' => true,
        'cpu' => true,
        'process_stats' => true,
        'hostname' => true,
        'distro' => true,
        'devices' => true,
        'model' => true,
        'numLoggedIn' => true,
        'virtualization' => true,
        'duplicate_mounts' => true,
        'temps' => true,
        'raid' => true,
        'battery' => true,
        'sound' => true,
        'wifi' => true,
        'services' => true,
    ],

    'hide' => [
        'filesystems' => [
            'tmpfs',
            'ecryptfs',
            'nfsd',
            'rpc_pipefs',
            'usbfs',
            'devpts',
            'fusectl',
            'securityfs',
            'fuse.truecrypt',
        ],
        'storage_devices' => [
            'gvfs-fuse-daemon',
            'none',
        ],
        'mountpoints_regex' => [],
        'fs_mount_options' => [
            'ecryptfs',
        ],
        'sg' => true,
    ],

    'raid' => [
        'gmirror' => false,
        'mdadm' => false,
    ],

    'temps' => [
        'hwmon' => true,
        'hddtemp' => false,
        'mbmon' => false,
        'sensord' => false,
    ],
    'temps_show0rpmfans' => false,
    
    'hddtemp' => [
        'mode' => 'daemon',
        'address' => [
            'host' => 'localhost',
            'port' => 7634,
        ],
    ],

    'mbmon' => [
        'address' => [
            'host' => 'localhost',
            'port' => 411,
        ],
    ],

    'additional_paths'=> [],
    'services' => [
        'pidFiles' => [],
        'executables' => [],
    ],
    'show_errors'=> false,
    'timer'=> false,
    'compress_content'=> true,
    'sudo_apps'=> [],
];
```