### PR TITLE
Update standalone_autoload.php

### DIFF
--- a/standalone_autoload.php
+++ b/standalone_autoload.php
@@ -3,7 +3,7 @@
 // Exclusively used for index.php functionality (not using a library) and unit tests
 spl_autoload_register(function ($n) {
 
-  $path = __DIR__.'/src/'.str_replace('\\', '/', $n).'.php';
+  $path = __DIR__.'/src/'.str_replace('\\', DIRECTORY_SEPARATOR, $n).'.php';
 
   if (!$path) {
       return;


### PR DESCRIPTION
use the `DIRECTORY_SEPARATOR` constant for cross os compatibility.