### PR TITLE
Update Linux.php

### DIFF
--- a/src/Linfo/OS/Linux.php
+++ b/src/Linfo/OS/Linux.php
@@ -191,12 +191,12 @@ class Linux extends Unixcommon
 
         // Get individual vals
         $return['type'] = 'Physical';
-        $return['total'] = $memVals['MemTotal'] * 1024;
-        $return['free'] = $memVals['MemFree'] * 1024 + $memVals['Cached'] * 1024 + $memVals['Buffers'] * 1024;
-        $return['swapTotal'] = $memVals['SwapTotal'] * 1024;
-        $return['swapFree'] = $memVals['SwapFree'] * 1024 + $memVals['SwapCached'] * 1024;
-        $return['swapCached'] = $memVals['SwapCached'] * 1024;
-        $return['swapInfo'] = $swapVals;
+        $return['total'] = @$memVals['MemTotal'] * 1024;
+        $return['free'] = @$memVals['MemFree'] * 1024 + @$memVals['Cached'] * 1024 + @$memVals['Buffers'] * 1024;
+        $return['swapTotal'] = @$memVals['SwapTotal'] * 1024;
+        $return['swapFree'] = @$memVals['SwapFree'] * 1024 + @$memVals['SwapCached'] * 1024;
+        $return['swapCached'] = @$memVals['SwapCached'] * 1024;
+        $return['swapInfo'] = @$swapVals;
 
         // Return it
         return $return;


### PR DESCRIPTION
Silence errors for missing /proc/meminfo keys.

On my OpenVZ Guest container, some values are not available inside the container and PHP will throw notices for invalid keys. 
This PR will silently ignore those notices. The calculation will still be correct as the NULL value will interpolate to zero in the math operations.

