### PR TITLE
fix: fixing darwin load regex

### DIFF
--- a/src/Linfo/OS/Darwin.php
+++ b/src/Linfo/OS/Darwin.php
@@ -613,7 +613,7 @@ class Darwin extends BSDcommon
 
         $loads = $this->sysctl['vm.loadavg'];
 
-        if (preg_match('/([\d\.]+) ([\d\.]+) ([\d\.]+)/', $loads, $m)) {
+        if (preg_match('/([\d\.\,]+) ([\d\.\,]+) ([\d\.\,]+)/', $loads, $m)) {
             return array_combine(array('now', '5min', '15min'), array_slice($m, 1, 3));
         } else {
             return array();


### PR DESCRIPTION
![captura de tela 2016-07-09 as 16 53 56](https://cloud.githubusercontent.com/assets/2898638/16710241/c3c3187e-45f5-11e6-81c6-e58baadc9487.png)

in some languages (like 🇧🇷) the "decimal point" is a comma instead dot.