### PR TITLE
Fix Travis-CI Build Error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,4 +21,4 @@ install:
 
 script: 
  - cd tests
- - ../vendor/bin/phpunit'
+ - ../vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ before_install:
  - travis_retry composer self-update
  - travis_retry composer require "phpunit/phpunit:${PHPUNIT_VERSION}" --no-interaction --no-update
 
+install: 
+ - travis_retry composer update --prefer-dist --no-interaction
+
 script: 
  - cd tests
  - ../vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: php
 php:
 # - 5.2 # Fuck this
- - 5.3
+# - 5.3 # PHP 5.3 is no longer supported
  - 5.4
  - 5.5
  - 5.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,24 @@
-language: php
+language: 
+ - php
+
+env:
+ - PHPUNIT_VERSION=4.8.*
+
 php:
-# - 5.2 # Fuck this
-# - 5.3 # PHP 5.3 is no longer supported
  - 5.4
  - 5.5
  - 5.6
  - 7.0
  - 7.1
  - hhvm
-script: 'cd tests && phpunit'
+
+before_install:
+  - travis_retry composer self-update
+  - travis_retry composer require "phpunit/phpunit:${PHPUNIT_VERSION}" --no-interaction --no-update
+
+install: 
+  - travis_retry composer update --prefer-source --no-interaction
+
+script: 
+ - cd tests
+ - ../vendor/bin/phpunit'

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,6 @@ php:
  - 5.5
  - 5.6
  - 7.0
+ - 7.1
+ - hhvm
 script: 'cd tests && phpunit'

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,8 @@ php:
  - hhvm
 
 before_install:
-  - travis_retry composer self-update
-  - travis_retry composer require "phpunit/phpunit:${PHPUNIT_VERSION}" --no-interaction --no-update
-
-install: 
-  - travis_retry composer update --prefer-source --no-interaction
+ - travis_retry composer self-update
+ - travis_retry composer require "phpunit/phpunit:${PHPUNIT_VERSION}" --no-interaction --no-update
 
 script: 
  - cd tests

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ var_dump($parser->getCPU()); // and a whole lot more
    - more
 
 ## System requirements: 
- - PHP 5.3
+ - PHP 5.4
  - pcre extension
 
 #### Windows


### PR DESCRIPTION
From [TravisCI job log](https://travis-ci.org/jrgp/linfo/jobs/259660523), [the URL for downloading PHP 5.3](https://s3.amazonaws.com/travis-php-archives/binaries/ubuntu/14.04/x86_64/php-5.3.tar.bz2) is missing.

I think it'd be better to remove test for PHP 5.3 since [it's no longer supported](http://php.net/eol.php).