### PR TITLE
Add `getModel` method to fix `Method getModel not present` error 

### DIFF
--- a/src/Linfo/OS/Windows.php
+++ b/src/Linfo/OS/Windows.php
@@ -766,4 +766,15 @@ class Windows extends OS
 
         return ($a['mount'] > $b['mount']) ? 1 : -1;
     }
+    
+    /**
+     * Fix error 'Method getModel not present' in Windows (XAMPP).
+     * 
+     * @access public
+     * @return void
+     */
+    public function getModel()
+    {
+        return null;
+    }
 }


### PR DESCRIPTION
Add `getModel` method to fix `Method getModel not present` error in the Windows machine (XAMPP). The method simply return `null`. 