### PR TITLE
fix typo

### DIFF
--- a/src/Linfo/OS/Windows.php
+++ b/src/Linfo/OS/Windows.php
@@ -564,7 +564,7 @@ class Windows extends OS
                 );
                 $return[$net->Name]['sent'] = array(
                     'bytes' => (int) $netspeed->BytesSentPersec,
-                    'erros' => 0,
+                    'errors' => 0,
                     'packets' => (int) $netspeed->PacketsSentPersec,
                 );
             }


### PR DESCRIPTION
fix `erros` -> `errors` for windows