### PR TITLE
Update test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Linfo - Server stats UI/library
 
-![Travis tests](https://api.travis-ci.org/jrgp/linfo.svg)
+[![Build Status](https://travis-ci.org/jrgp/linfo.svg?branch=master)](https://travis-ci.org/jrgp/linfo)
 
 
 ### Linfo is a:

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     }
   ],
   "require":{
-    "php":">=5.3.0",
+    "php":">=5.4.0",
     "ext-pcre":"*"
   },
   "require-dev":{

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -3,4 +3,4 @@
 define('LINFO_TESTING', 1);
 define('LINFO_TESTDIR', dirname(__FILE__));
 
-require_once dirname(dirname(__FILE__)).'/standalone_autoload.php';
+require_once dirname(dirname(__FILE__)) . '/standalone_autoload.php';

--- a/tests/linfo/LinfoCommonTest.php
+++ b/tests/linfo/LinfoCommonTest.php
@@ -5,27 +5,27 @@ use \Linfo\Linfo;
 
 class CommonTest extends PHPUnit_Framework_TestCase
 {
-    protected static $linfo;
+  protected static $linfo;
 
-    public static function setUpBeforeClass()
-    {
-        self::$linfo = new Linfo();
-    }
+  public static function setUpBeforeClass()
+  {
+    self::$linfo = new Linfo();
+  }
 
-    public static function tearDownAfterClass()
-    {
-        Common::unconfig();
-    }
+  public static function tearDownAfterClass()
+  {
+    Common::unconfig();
+  }
 
   /**
    * @test
    */
   public function arrayAppendString()
   {
-      $strs = array('str1', 'str2', 'str3');
-      $expected = array('str1_suffix', 'str2_suffix', 'str3_suffix');
+    $strs = ['str1', 'str2', 'str3'];
+    $expected = ['str1_suffix', 'str2_suffix', 'str3_suffix'];
 
-      $this->assertEquals(Common::arrayAppendString($strs, '_suffix'), $expected);
+    $this->assertEquals(Common::arrayAppendString($strs, '_suffix'), $expected);
   }
 
   /**
@@ -33,7 +33,7 @@ class CommonTest extends PHPUnit_Framework_TestCase
    */
   public function xmlStringSanitize()
   {
-      $this->assertEquals(Common::xmlStringSanitize('te!@#$%^st'), 'te_st');
+    $this->assertEquals(Common::xmlStringSanitize('te!@#$%^st'), 'te_st');
   }
 
   /**
@@ -41,8 +41,8 @@ class CommonTest extends PHPUnit_Framework_TestCase
    */
   public function anyInArray()
   {
-      $this->assertTrue(Common::anyInArray(array(1, 2, 3, 4, 5), array(5, 6, 7)));
-      $this->assertFalse(Common::anyInArray(array(8, 9, 10), array(11, 12, 3)));
+    $this->assertTrue(Common::anyInArray([1, 2, 3, 4, 5], [5, 6, 7]));
+    $this->assertFalse(Common::anyInArray([8, 9, 10], [11, 12, 3]));
   }
 
   /**
@@ -50,13 +50,13 @@ class CommonTest extends PHPUnit_Framework_TestCase
    */
   public function locateActualPath()
   {
-      $paths = array(
-      LINFO_TESTDIR.'/files/test1.txt',
-      LINFO_TESTDIR.'/files/test2.txt',
-      LINFO_TESTDIR.'/files/test3.txt',
-    );
-      $real = LINFO_TESTDIR.'/files/test2.txt';
-      $this->assertEquals($real, Common::locateActualPath($paths));
+    $paths = [
+        LINFO_TESTDIR . '/files/test1.txt',
+        LINFO_TESTDIR . '/files/test2.txt',
+        LINFO_TESTDIR . '/files/test3.txt',
+    ];
+    $real = LINFO_TESTDIR . '/files/test2.txt';
+    $this->assertEquals($real, Common::locateActualPath($paths));
   }
 
   /**
@@ -64,8 +64,8 @@ class CommonTest extends PHPUnit_Framework_TestCase
    */
   public function getIntFromFile()
   {
-      $file = LINFO_TESTDIR.'/files/intfile.txt';
-      $this->assertEquals(101, Common::getIntFromFile($file));
+    $file = LINFO_TESTDIR . '/files/intfile.txt';
+    $this->assertEquals(101, Common::getIntFromFile($file));
   }
 
   /**
@@ -73,8 +73,8 @@ class CommonTest extends PHPUnit_Framework_TestCase
    */
   public function getVarFromFile()
   {
-      $file = LINFO_TESTDIR.'/files/varfile.php';
-      $this->assertEquals('foo', Common::getVarFromFile($file, 'var'));
+    $file = LINFO_TESTDIR . '/files/varfile.php';
+    $this->assertEquals('foo', Common::getVarFromFile($file, 'var'));
   }
 
   /**
@@ -82,8 +82,8 @@ class CommonTest extends PHPUnit_Framework_TestCase
    */
   public function byteConvert()
   {
-      $this->assertEquals('1000 KiB', Common::byteConvert(1024000));
-      $this->assertEquals('1 GiB', Common::byteConvert(1073741824));
+    $this->assertEquals('1000 KiB', Common::byteConvert(1024000));
+    $this->assertEquals('1 GiB', Common::byteConvert(1073741824));
   }
 
   /**
@@ -91,7 +91,7 @@ class CommonTest extends PHPUnit_Framework_TestCase
    */
   public function secondsConvert()
   {
-      // this is incorrect
+    // this is incorrect
     $this->assertEquals('4 days, 4 hours, 30 seconds', Common::secondsConvert(360000));
 
     // this says '1 hours, 30 seconds' instead. need to find out why...
@@ -103,9 +103,9 @@ class CommonTest extends PHPUnit_Framework_TestCase
    */
   public function getContents()
   {
-      $contents = "lineone\nlinetwo\nline3";
-      $file = LINFO_TESTDIR.'/files/lines.txt';
-      $this->assertEquals($contents, Common::getContents($file));
+    $contents = "lineone\nlinetwo\nline3";
+    $file = LINFO_TESTDIR . '/files/lines.txt';
+    $this->assertEquals($contents, Common::getContents($file));
   }
 
   /**
@@ -113,8 +113,8 @@ class CommonTest extends PHPUnit_Framework_TestCase
    */
   public function getLines()
   {
-      $lines = array("lineone\n", "linetwo\n", "line3\n");
-      $file = LINFO_TESTDIR.'/files/lines.txt';
-      $this->assertEquals($lines, Common::getLines($file));
+    $lines = ["lineone\n", "linetwo\n", "line3\n"];
+    $file = LINFO_TESTDIR . '/files/lines.txt';
+    $this->assertEquals($lines, Common::getLines($file));
   }
 }

--- a/tests/linfo/LinfoErrorTest.php
+++ b/tests/linfo/LinfoErrorTest.php
@@ -10,13 +10,13 @@ class ErrorTest extends PHPUnit_Framework_TestCase
    */
   public function add()
   {
-      Errors::add('testing', 'testing 123');
-      Errors::add('testing', 'testing 456');
-      $this->assertCount(2, Errors::show());
+    Errors::add('testing', 'testing 123');
+    Errors::add('testing', 'testing 456');
+    $this->assertCount(2, Errors::show());
   }
 
-    public function tearDown()
-    {
-        Errors::clear();
-    }
+  public function tearDown()
+  {
+    Errors::clear();
+  }
 }

--- a/tests/linfo/LinfoTest.php
+++ b/tests/linfo/LinfoTest.php
@@ -5,25 +5,25 @@ use \Linfo\Common;
 
 class LinfoTest extends PHPUnit_Framework_TestCase
 {
-    protected static $linfo;
+  protected static $linfo;
 
-    public static function setUpBeforeClass()
-    {
-        self::$linfo = new Linfo();
-    }
+  public static function setUpBeforeClass()
+  {
+    self::$linfo = new Linfo();
+  }
 
-    public static function tearDownAfterClass()
-    {
-        self::$linfo = null;
-        Common::unconfig();
-    }
+  public static function tearDownAfterClass()
+  {
+    self::$linfo = null;
+    Common::unconfig();
+  }
 
   /**
    * @test
    */
   public static function getLang()
   {
-      self::assertInternalType('array', self::$linfo->getLang());
+    self::assertInternalType('array', self::$linfo->getLang());
   }
 
   /**
@@ -31,7 +31,7 @@ class LinfoTest extends PHPUnit_Framework_TestCase
    */
   public static function getSettings()
   {
-      self::assertInternalType('array', self::$linfo->getSettings());
+    self::assertInternalType('array', self::$linfo->getSettings());
   }
 
   /**
@@ -39,7 +39,7 @@ class LinfoTest extends PHPUnit_Framework_TestCase
    */
   public static function getAppName()
   {
-      self::assertInternalType('string', self::$linfo->getAppName());
+    self::assertInternalType('string', self::$linfo->getAppName());
   }
 
   /**
@@ -47,7 +47,7 @@ class LinfoTest extends PHPUnit_Framework_TestCase
    */
   public static function getVersion()
   {
-      self::assertInternalType('string', self::$linfo->getVersion());
+    self::assertInternalType('string', self::$linfo->getVersion());
   }
 
   /**
@@ -55,7 +55,7 @@ class LinfoTest extends PHPUnit_Framework_TestCase
    */
   public static function getTimeStart()
   {
-      self::assertTrue(is_float(self::$linfo->getTimeStart()));
+    self::assertTrue(is_float(self::$linfo->getTimeStart()));
   }
 
   /**
@@ -63,6 +63,6 @@ class LinfoTest extends PHPUnit_Framework_TestCase
    */
   public static function getParser()
   {
-      self::assertInstanceOf('\\Linfo\\OS\\OS', self::$linfo->getParser());
+    self::assertInstanceOf('\\Linfo\\OS\\OS', self::$linfo->getParser());
   }
 }

--- a/tests/linfo/LinfoTimerTest.php
+++ b/tests/linfo/LinfoTimerTest.php
@@ -4,20 +4,20 @@ use \Linfo\Meta\Timer;
 
 class LinfoTimerTest extends PHPUnit_Framework_TestCase
 {
-    /**
+  /**
    * @test
    */
   public function runTimers()
   {
-      $t1 = new Timer('test1');
-      unset($t1);
-      $t2 = new Timer('test2');
-      unset($t2);
-      $this->assertCount(2, Timer::getResults());
+    $t1 = new Timer('test1');
+    unset($t1);
+    $t2 = new Timer('test2');
+    unset($t2);
+    $this->assertCount(2, Timer::getResults());
   }
 
-    public function tearDown()
-    {
-        Timer::clear();
-    }
+  public function tearDown()
+  {
+    Timer::clear();
+  }
 }

--- a/tests/os/Darwin/Darwin.php
+++ b/tests/os/Darwin/Darwin.php
@@ -100,8 +100,8 @@ class OS_DarwinTest extends PHPUnit_Framework_TestCase
       foreach (['bytes', 'errors', 'packets'] as $key) {
         self::assertArrayHasKey($key, $nic['sent']);
         self::assertArrayHasKey($key, $nic['recieved']);
-        self::assertTrue(is_numeric($nic['sent'][$key]));
-        self::assertTrue(is_numeric($nic['recieved'][$key]));
+        self::assertInternalType('numeric', $nic['sent'][$key]);
+        self::assertInternalType('numeric', $nic['recieved'][$key]);
       }
     }
   }
@@ -151,10 +151,10 @@ class OS_DarwinTest extends PHPUnit_Framework_TestCase
       if (is_array($drive['partitions'])) {
         foreach ($drive['partitions'] as $partition) {
           self::assertArrayHasKey('size', $partition);
-          self::assertTrue(is_numeric($partition['size']));
+          self::assertInternalType('numeric', $partition['size']);
         }
       }
-      self::assertTrue(is_numeric($drive['size']));
+      self::assertInternalType('numeric', $drive['size']);
     }
   }
 

--- a/tests/os/Darwin/Darwin.php
+++ b/tests/os/Darwin/Darwin.php
@@ -3,31 +3,34 @@
 use \Linfo\Common;
 use \Linfo\Linfo;
 
-if (PHP_OS == 'Darwin') {
-    class OS_DarwinTest extends PHPUnit_Framework_TestCase
-    {
-        protected static $parser;
+class OS_DarwinTest extends PHPUnit_Framework_TestCase
+{
+  protected static $parser;
 
-        public static function setUpBeforeClass()
-        {
-            $linfo = new Linfo();
-            self::$parser = $linfo->getParser();
+  public static function setUpBeforeClass()
+  {
+    if (PHP_OS !== 'Darwin') {
+      self::markTestSkipped('Skip tests for Darwin on other os');
+    }
 
-            self::assertInstanceOf('\\Linfo\\OS\\Darwin', self::$parser);
-        }
+    $linfo = new Linfo();
+    self::$parser = $linfo->getParser();
 
-        public static function tearDownAfterClass()
-        {
-            self::$parser = null;
-            Common::unconfig();
-        }
+    self::assertInstanceOf('\\Linfo\\OS\\Darwin', self::$parser);
+  }
+
+  public static function tearDownAfterClass()
+  {
+    self::$parser = null;
+    Common::unconfig();
+  }
 
   /**
    * @test
    */
   public static function getOS()
   {
-      self::assertStringStartsWith('Darwin', self::$parser->getOS());
+    self::assertStringStartsWith('Darwin', self::$parser->getOS());
   }
 
   /**
@@ -35,7 +38,7 @@ if (PHP_OS == 'Darwin') {
    */
   public static function getKernel()
   {
-      self::assertInternalType('string', self::$parser->getKernel());
+    self::assertInternalType('string', self::$parser->getKernel());
   }
 
   /**
@@ -43,7 +46,7 @@ if (PHP_OS == 'Darwin') {
    */
   public static function getModel()
   {
-      self::assertInternalType('string', self::$parser->getModel());
+    self::assertInternalType('string', self::$parser->getModel());
   }
 
   /**
@@ -51,7 +54,7 @@ if (PHP_OS == 'Darwin') {
    */
   public static function getHostname()
   {
-      self::assertInternalType('string', self::$parser->getHostname());
+    self::assertInternalType('string', self::$parser->getHostname());
   }
 
   /**
@@ -59,7 +62,7 @@ if (PHP_OS == 'Darwin') {
    */
   public static function getCPUArchitecture()
   {
-      self::assertInternalType('string', self::$parser->getCPUArchitecture());
+    self::assertInternalType('string', self::$parser->getCPUArchitecture());
   }
 
   /**
@@ -67,16 +70,16 @@ if (PHP_OS == 'Darwin') {
    */
   public static function getMounts()
   {
-      $mounts = self::$parser->getMounts();
-      self::assertInternalType('array', $mounts);
-      foreach ($mounts as $mount) {
-          foreach (array('device', 'mount', 'type', 'size', 'used', 'free', 'free_percent', 'used_percent') as $key) {
-              self::assertArrayHasKey($key, $mount);
-          }
-          self::assertInternalType('string', $mount['device']);
-          self::assertInternalType('string', $mount['mount']);
-          self::assertInternalType('string', $mount['type']);
+    $mounts = self::$parser->getMounts();
+    self::assertInternalType('array', $mounts);
+    foreach ($mounts as $mount) {
+      foreach (['device', 'mount', 'type', 'size', 'used', 'free', 'free_percent', 'used_percent'] as $key) {
+        self::assertArrayHasKey($key, $mount);
       }
+      self::assertInternalType('string', $mount['device']);
+      self::assertInternalType('string', $mount['mount']);
+      self::assertInternalType('string', $mount['type']);
+    }
   }
 
   /**
@@ -84,23 +87,23 @@ if (PHP_OS == 'Darwin') {
    */
   public static function getNet()
   {
-      $nics = self::$parser->getNet();
-      self::assertInternalType('array', $nics);
-      foreach ($nics as $nic) {
-          foreach (array('sent', 'recieved', 'state', 'type') as $key) {
-              self::assertArrayHasKey($key, $nic);
-          }
-          self::assertInternalType('string', $nic['state']);
-          self::assertInternalType('string', $nic['type']);
-          self::assertInternalType('array', $nic['sent']);
-          self::assertInternalType('array', $nic['recieved']);
-          foreach (array('bytes', 'errors', 'packets') as $key) {
-              self::assertArrayHasKey($key, $nic['sent']);
-              self::assertArrayHasKey($key, $nic['recieved']);
-              self::assertTrue(is_numeric($nic['sent'][$key]));
-              self::assertTrue(is_numeric($nic['recieved'][$key]));
-          }
+    $nics = self::$parser->getNet();
+    self::assertInternalType('array', $nics);
+    foreach ($nics as $nic) {
+      foreach (['sent', 'recieved', 'state', 'type'] as $key) {
+        self::assertArrayHasKey($key, $nic);
       }
+      self::assertInternalType('string', $nic['state']);
+      self::assertInternalType('string', $nic['type']);
+      self::assertInternalType('array', $nic['sent']);
+      self::assertInternalType('array', $nic['recieved']);
+      foreach (['bytes', 'errors', 'packets'] as $key) {
+        self::assertArrayHasKey($key, $nic['sent']);
+        self::assertArrayHasKey($key, $nic['recieved']);
+        self::assertTrue(is_numeric($nic['sent'][$key]));
+        self::assertTrue(is_numeric($nic['recieved'][$key]));
+      }
+    }
   }
 
   /**
@@ -108,16 +111,16 @@ if (PHP_OS == 'Darwin') {
    */
   public static function getCPU()
   {
-      $cpus = self::$parser->getCPU();
-      self::assertInternalType('array', $cpus);
-      foreach ($cpus as $cpu) {
-          self::assertArrayHasKey('Model', $cpu);
-          self::assertArrayHasKey('MHz', $cpu);
-          self::assertArrayHasKey('Vendor', $cpu);
-          self::assertInternalType('string', $cpu['Model']);
-          self::assertInternalType('int', $cpu['MHz']);
-          self::assertInternalType('string', $cpu['Vendor']);
-      }
+    $cpus = self::$parser->getCPU();
+    self::assertInternalType('array', $cpus);
+    foreach ($cpus as $cpu) {
+      self::assertArrayHasKey('Model', $cpu);
+      self::assertArrayHasKey('MHz', $cpu);
+      self::assertArrayHasKey('Vendor', $cpu);
+      self::assertInternalType('string', $cpu['Model']);
+      self::assertInternalType('int', $cpu['MHz']);
+      self::assertInternalType('string', $cpu['Vendor']);
+    }
   }
 
   /**
@@ -125,13 +128,13 @@ if (PHP_OS == 'Darwin') {
    */
   public static function getBattery()
   {
-      $batteries = self::$parser->getBattery();
-      self::assertInternalType('array', $batteries);
-      foreach ($batteries as $bat) {
-          foreach (array('charge_full', 'charge_now', 'percentage', 'state') as $key) {
-              self::assertArrayHasKey($key, $bat);
-          }
+    $batteries = self::$parser->getBattery();
+    self::assertInternalType('array', $batteries);
+    foreach ($batteries as $bat) {
+      foreach (['charge_full', 'charge_now', 'percentage', 'state'] as $key) {
+        self::assertArrayHasKey($key, $bat);
       }
+    }
   }
 
   /**
@@ -139,20 +142,20 @@ if (PHP_OS == 'Darwin') {
    */
   public static function getHD()
   {
-      $drives = self::$parser->getHD();
-      self::assertInternalType('array', $drives);
-      foreach ($drives as $drive) {
-          foreach (array('name', 'vendor', 'device', 'reads', 'writes', 'size', 'partitions') as $key) {
-              self::assertArrayHasKey($key, $drive);
-          }
-          if (is_array($drive['partitions'])) {
-              foreach ($drive['partitions'] as $partition) {
-                  self::assertArrayHasKey('size', $partition);
-                  self::assertTrue(is_numeric($partition['size']));
-              }
-          }
-          self::assertTrue(is_numeric($drive['size']));
+    $drives = self::$parser->getHD();
+    self::assertInternalType('array', $drives);
+    foreach ($drives as $drive) {
+      foreach (['name', 'vendor', 'device', 'reads', 'writes', 'size', 'partitions'] as $key) {
+        self::assertArrayHasKey($key, $drive);
       }
+      if (is_array($drive['partitions'])) {
+        foreach ($drive['partitions'] as $partition) {
+          self::assertArrayHasKey('size', $partition);
+          self::assertTrue(is_numeric($partition['size']));
+        }
+      }
+      self::assertTrue(is_numeric($drive['size']));
+    }
   }
 
   /**
@@ -160,7 +163,7 @@ if (PHP_OS == 'Darwin') {
    */
   public static function getUpTime()
   {
-      self::assertInternalType('array', self::$parser->getUpTime());
+    self::assertInternalType('array', self::$parser->getUpTime());
   }
 
   /**
@@ -168,11 +171,11 @@ if (PHP_OS == 'Darwin') {
    */
   public static function getLoad()
   {
-      $load = self::$parser->getLoad();
-      self::assertInternalType('array', $load);
-      foreach (array('now', '5min', '15min') as $key) {
-          self::assertArrayHasKey($key, $load);
-      }
+    $load = self::$parser->getLoad();
+    self::assertInternalType('array', $load);
+    foreach (['now', '5min', '15min'] as $key) {
+      self::assertArrayHasKey($key, $load);
+    }
   }
 
   /**
@@ -180,16 +183,16 @@ if (PHP_OS == 'Darwin') {
    */
   public static function getProcessStats()
   {
-      $stats = self::$parser->getProcessStats();
-      self::assertInternalType('array', $stats);
-      foreach (array('totals', 'proc_total') as $key) {
-          self::assertArrayHasKey($key, $stats);
-      }
-      self::assertInternalType('int', $stats['proc_total']);
-      foreach (array('running', 'zombie', 'stopped', 'sleeping', 'idle') as $key) {
-          self::assertArrayHasKey($key, $stats['totals']);
-          self::assertInternalType('int', $stats['totals'][$key]);
-      }
+    $stats = self::$parser->getProcessStats();
+    self::assertInternalType('array', $stats);
+    foreach (['totals', 'proc_total'] as $key) {
+      self::assertArrayHasKey($key, $stats);
+    }
+    self::assertInternalType('int', $stats['proc_total']);
+    foreach (['running', 'zombie', 'stopped', 'sleeping', 'idle'] as $key) {
+      self::assertArrayHasKey($key, $stats['totals']);
+      self::assertInternalType('int', $stats['totals'][$key]);
+    }
   }
 
   /**
@@ -197,11 +200,10 @@ if (PHP_OS == 'Darwin') {
    */
   public static function getRam()
   {
-      $stats = self::$parser->getRam();
-      self::assertInternalType('array', $stats);
-      foreach (array('total', 'type', 'free', 'swapTotal', 'swapFree', 'swapInfo') as $key) {
-          self::assertArrayHasKey($key, $stats);
-      }
-  }
+    $stats = self::$parser->getRam();
+    self::assertInternalType('array', $stats);
+    foreach (['total', 'type', 'free', 'swapTotal', 'swapFree', 'swapInfo'] as $key) {
+      self::assertArrayHasKey($key, $stats);
     }
+  }
 }

--- a/tests/os/FreeBSD/FreeBSD.php
+++ b/tests/os/FreeBSD/FreeBSD.php
@@ -75,8 +75,8 @@ class OS_FreeBSDTest extends PHPUnit_Framework_TestCase
       foreach (['bytes', 'errors', 'packets'] as $key) {
         self::assertArrayHasKey($key, $nic['sent']);
         self::assertArrayHasKey($key, $nic['recieved']);
-        self::assertTrue(is_numeric($nic['sent'][$key]));
-        self::assertTrue(is_numeric($nic['recieved'][$key]));
+        self::assertInternalType('numeric', $nic['sent'][$key]);
+        self::assertInternalType('numeric', $nic['recieved'][$key]);
       }
     }
   }

--- a/tests/os/FreeBSD/FreeBSD.php
+++ b/tests/os/FreeBSD/FreeBSD.php
@@ -3,31 +3,34 @@
 use \Linfo\Common;
 use \Linfo\Linfo;
 
-if (PHP_OS == 'FreeBSD') {
-    class OS_FreeBSDTest extends PHPUnit_Framework_TestCase
-    {
-        protected static $parser;
+class OS_FreeBSDTest extends PHPUnit_Framework_TestCase
+{
+  protected static $parser;
 
-        public static function setUpBeforeClass()
-        {
-            $linfo = new Linfo();
-            self::$parser = $linfo->getParser();
+  public static function setUpBeforeClass()
+  {
+    if (PHP_OS !== 'FreeBSD') {
+      self::markTestSkipped('Skip tests for FreeBSD on other os');
+    }
 
-            self::assertInstanceOf('\\Linfo\\OS\\FreeBSD', self::$parser);
-        }
+    $linfo = new Linfo();
+    self::$parser = $linfo->getParser();
 
-        public static function tearDownAfterClass()
-        {
-            self::$parser = null;
-            Common::unconfig();
-        }
+    self::assertInstanceOf('\\Linfo\\OS\\FreeBSD', self::$parser);
+  }
+
+  public static function tearDownAfterClass()
+  {
+    self::$parser = null;
+    Common::unconfig();
+  }
 
   /**
    * @test
    */
   public static function getOS()
   {
-      self::assertEquals('FreeBSD', self::$parser->getOS());
+    self::assertEquals('FreeBSD', self::$parser->getOS());
   }
 
   /**
@@ -35,7 +38,7 @@ if (PHP_OS == 'FreeBSD') {
    */
   public static function getKernel()
   {
-      self::assertInternalType('string', self::$parser->getKernel());
+    self::assertInternalType('string', self::$parser->getKernel());
   }
 
   /**
@@ -43,7 +46,7 @@ if (PHP_OS == 'FreeBSD') {
    */
   public static function getHostname()
   {
-      self::assertInternalType('string', self::$parser->getHostname());
+    self::assertInternalType('string', self::$parser->getHostname());
   }
 
   /**
@@ -51,7 +54,7 @@ if (PHP_OS == 'FreeBSD') {
    */
   public static function getCPUArchitecture()
   {
-      self::assertInternalType('string', self::$parser->getCPUArchitecture());
+    self::assertInternalType('string', self::$parser->getCPUArchitecture());
   }
 
   /**
@@ -59,23 +62,23 @@ if (PHP_OS == 'FreeBSD') {
    */
   public static function getNet()
   {
-      $nics = self::$parser->getNet();
-      self::assertInternalType('array', $nics);
-      foreach ($nics as $nic) {
-          foreach (array('sent', 'recieved', 'state', 'type') as $key) {
-              self::assertArrayHasKey($key, $nic);
-          }
-          self::assertInternalType('string', $nic['state']);
-          self::assertInternalType('string', $nic['type']);
-          self::assertInternalType('array', $nic['sent']);
-          self::assertInternalType('array', $nic['recieved']);
-          foreach (array('bytes', 'errors', 'packets') as $key) {
-              self::assertArrayHasKey($key, $nic['sent']);
-              self::assertArrayHasKey($key, $nic['recieved']);
-              self::assertTrue(is_numeric($nic['sent'][$key]));
-              self::assertTrue(is_numeric($nic['recieved'][$key]));
-          }
+    $nics = self::$parser->getNet();
+    self::assertInternalType('array', $nics);
+    foreach ($nics as $nic) {
+      foreach (['sent', 'recieved', 'state', 'type'] as $key) {
+        self::assertArrayHasKey($key, $nic);
       }
+      self::assertInternalType('string', $nic['state']);
+      self::assertInternalType('string', $nic['type']);
+      self::assertInternalType('array', $nic['sent']);
+      self::assertInternalType('array', $nic['recieved']);
+      foreach (['bytes', 'errors', 'packets'] as $key) {
+        self::assertArrayHasKey($key, $nic['sent']);
+        self::assertArrayHasKey($key, $nic['recieved']);
+        self::assertTrue(is_numeric($nic['sent'][$key]));
+        self::assertTrue(is_numeric($nic['recieved'][$key]));
+      }
+    }
   }
 
   /**
@@ -83,14 +86,14 @@ if (PHP_OS == 'FreeBSD') {
    */
   public static function getCPU()
   {
-      $cpus = self::$parser->getCPU();
-      self::assertInternalType('array', $cpus);
-      foreach ($cpus as $cpu) {
-          self::assertArrayHasKey('Model', $cpu);
-          self::assertArrayHasKey('MHz', $cpu);
-          self::assertInternalType('string', $cpu['Model']);
-          self::assertInternalType('int', $cpu['MHz']);
-      }
+    $cpus = self::$parser->getCPU();
+    self::assertInternalType('array', $cpus);
+    foreach ($cpus as $cpu) {
+      self::assertArrayHasKey('Model', $cpu);
+      self::assertArrayHasKey('MHz', $cpu);
+      self::assertInternalType('string', $cpu['Model']);
+      self::assertInternalType('int', $cpu['MHz']);
+    }
   }
 
   /**
@@ -98,7 +101,7 @@ if (PHP_OS == 'FreeBSD') {
    */
   public static function getUpTime()
   {
-      self::assertInternalType('array', self::$parser->getUpTime());
+    self::assertInternalType('array', self::$parser->getUpTime());
   }
 
   /**
@@ -106,11 +109,11 @@ if (PHP_OS == 'FreeBSD') {
    */
   public static function getLoad()
   {
-      $load = self::$parser->getLoad();
-      self::assertInternalType('array', $load);
-      foreach (array('now', '5min', '15min') as $key) {
-          self::assertArrayHasKey($key, $load);
-      }
+    $load = self::$parser->getLoad();
+    self::assertInternalType('array', $load);
+    foreach (['now', '5min', '15min'] as $key) {
+      self::assertArrayHasKey($key, $load);
+    }
   }
 
   /**
@@ -118,16 +121,16 @@ if (PHP_OS == 'FreeBSD') {
    */
   public static function getProcessStats()
   {
-      $stats = self::$parser->getProcessStats();
-      self::assertInternalType('array', $stats);
-      foreach (array('totals', 'proc_total') as $key) {
-          self::assertArrayHasKey($key, $stats);
-      }
-      self::assertInternalType('int', $stats['proc_total']);
-      foreach (array('running', 'zombie', 'stopped', 'sleeping', 'idle') as $key) {
-          self::assertArrayHasKey($key, $stats['totals']);
-          self::assertInternalType('int', $stats['totals'][$key]);
-      }
+    $stats = self::$parser->getProcessStats();
+    self::assertInternalType('array', $stats);
+    foreach (['totals', 'proc_total'] as $key) {
+      self::assertArrayHasKey($key, $stats);
+    }
+    self::assertInternalType('int', $stats['proc_total']);
+    foreach (['running', 'zombie', 'stopped', 'sleeping', 'idle'] as $key) {
+      self::assertArrayHasKey($key, $stats['totals']);
+      self::assertInternalType('int', $stats['totals'][$key]);
+    }
   }
 
   /**
@@ -135,11 +138,11 @@ if (PHP_OS == 'FreeBSD') {
    */
   public static function getRam()
   {
-      $stats = self::$parser->getRam();
-      self::assertInternalType('array', $stats);
-      foreach (array('total', 'type', 'free', 'swapTotal', 'swapFree', 'swapInfo') as $key) {
-          self::assertArrayHasKey($key, $stats);
-      }
+    $stats = self::$parser->getRam();
+    self::assertInternalType('array', $stats);
+    foreach (['total', 'type', 'free', 'swapTotal', 'swapFree', 'swapInfo'] as $key) {
+      self::assertArrayHasKey($key, $stats);
+    }
   }
 
   /**
@@ -147,17 +150,17 @@ if (PHP_OS == 'FreeBSD') {
    */
   public static function getMounts()
   {
-      $mounts = self::$parser->getMounts();
-      self::assertInternalType('array', $mounts);
-      foreach ($mounts as $mount) {
-          foreach (array('device', 'mount', 'type', 'size', 'used', 'free', 'free_percent', 'used_percent') as $key) {
-              self::assertArrayHasKey($key, $mount);
-          }
-          self::assertInternalType('string', $mount['device']);
-          self::assertInternalType('string', $mount['mount']);
-          self::assertInternalType('string', $mount['type']);
-          self::assertInternalType('array', $mount['options']);
+    $mounts = self::$parser->getMounts();
+    self::assertInternalType('array', $mounts);
+    foreach ($mounts as $mount) {
+      foreach (['device', 'mount', 'type', 'size', 'used', 'free', 'free_percent', 'used_percent'] as $key) {
+        self::assertArrayHasKey($key, $mount);
       }
+      self::assertInternalType('string', $mount['device']);
+      self::assertInternalType('string', $mount['mount']);
+      self::assertInternalType('string', $mount['type']);
+      self::assertInternalType('array', $mount['options']);
+    }
   }
 
   /**
@@ -165,14 +168,14 @@ if (PHP_OS == 'FreeBSD') {
    */
   public static function getDevs()
   {
-      $devs = self::$parser->getDevs();
-      self::assertInternalType('array', $devs);
-      foreach ($devs as $dev) {
-          foreach (array('vendor', 'device', 'type') as $key) {
-              self::assertArrayHasKey($key, $dev);
-              self::assertInternalType('string', $dev[$key]);
-          }
+    $devs = self::$parser->getDevs();
+    self::assertInternalType('array', $devs);
+    foreach ($devs as $dev) {
+      foreach (['vendor', 'device', 'type'] as $key) {
+        self::assertArrayHasKey($key, $dev);
+        self::assertInternalType('string', $dev[$key]);
       }
+    }
   }
 
   /**
@@ -180,13 +183,12 @@ if (PHP_OS == 'FreeBSD') {
    */
   public static function getHD()
   {
-      $drives = self::$parser->getHD();
-      self::assertInternalType('array', $drives);
-      foreach ($drives as $drive) {
-          foreach (array('name', 'vendor', 'device') as $key) {
-              self::assertArrayHasKey($key, $drive);
-          }
+    $drives = self::$parser->getHD();
+    self::assertInternalType('array', $drives);
+    foreach ($drives as $drive) {
+      foreach (['name', 'vendor', 'device'] as $key) {
+        self::assertArrayHasKey($key, $drive);
       }
-  }
     }
+  }
 }

--- a/tests/os/Linux/GenericDistro.php
+++ b/tests/os/Linux/GenericDistro.php
@@ -3,34 +3,37 @@
 use \Linfo\Common;
 use \Linfo\Linfo;
 
-if (PHP_OS == 'Linux') {
-
 /*
  * Validate most of the regexes/file parsing, targeting custom known real
  * Linux files taken from the wild
  *
  * Also, thank FUCK for var_export()
  */
+
 class LinuxGenericDistroTest extends PHPUnit_Framework_TestCase
 {
-    protected static $parser;
+  protected static $parser;
 
-    public static function setUpBeforeClass()
-    {
-        Common::$path_prefix = dirname(dirname(__FILE__)).'/../files/linux/generic_distro';
-        $linfo = new Linfo();
-        self::$parser = $linfo->getParser();
+  public static function setUpBeforeClass()
+  {
+    if (PHP_OS !== 'Linux') {
+      self::markTestSkipped('Skip tests for Linux on other os');
     }
+
+    Common::$path_prefix = dirname(dirname(__FILE__)) . '/../files/linux/generic_distro';
+    $linfo = new Linfo();
+    self::$parser = $linfo->getParser();
+  }
 
   /**
    * @test
    */
   public static function checkDistro()
   {
-      self::assertEquals(array(
-      'name' => 'Ubuntu',
-      'version' => '14.04 (Trusty)',
-    ), self::$parser->getDistro());
+    self::assertEquals([
+        'name' => 'Ubuntu',
+        'version' => '14.04 (Trusty)',
+    ], self::$parser->getDistro());
   }
 
   /**
@@ -38,11 +41,11 @@ class LinuxGenericDistroTest extends PHPUnit_Framework_TestCase
    */
   public static function checkLoad()
   {
-      self::assertEquals(array(
-      'now' => '0.23',
-      '5min' => '0.29',
-      '15min' => '0.31',
-    ), self::$parser->getLoad());
+    self::assertEquals([
+        'now' => '0.23',
+        '5min' => '0.29',
+        '15min' => '0.31',
+    ], self::$parser->getLoad());
   }
 
   /**
@@ -50,7 +53,7 @@ class LinuxGenericDistroTest extends PHPUnit_Framework_TestCase
    */
   public static function checkHostname()
   {
-      self::assertEquals('machina.jrgp.us', self::$parser->getHostname());
+    self::assertEquals('machina.jrgp.us', self::$parser->getHostname());
   }
 
   /**
@@ -58,7 +61,7 @@ class LinuxGenericDistroTest extends PHPUnit_Framework_TestCase
    */
   public static function checkKernel()
   {
-      self::assertEquals('3.17.3', self::$parser->getKernel());
+    self::assertEquals('3.17.3', self::$parser->getKernel());
   }
 
   /**
@@ -66,7 +69,7 @@ class LinuxGenericDistroTest extends PHPUnit_Framework_TestCase
    */
   public static function checkModel()
   {
-      self::assertEquals('PowerEdge R610 (Dell Inc. 0K399H)', self::$parser->getModel());
+    self::assertEquals('PowerEdge R610 (Dell Inc. 0K399H)', self::$parser->getModel());
   }
 
   /**
@@ -74,16 +77,16 @@ class LinuxGenericDistroTest extends PHPUnit_Framework_TestCase
    */
   public static function checkSoundCards()
   {
-      self::assertEquals(array(
-      0 => array(
-        'number' => '0',
-        'card' => 'HDA-Intel - HDA Intel HDMI',
-      ),
-      1 => array(
-        'number' => '1',
-        'card' => 'HDA-Intel - HDA Intel PCH',
-      ),
-    ), self::$parser->getSoundCards());
+    self::assertEquals([
+        0 => [
+            'number' => '0',
+            'card' => 'HDA-Intel - HDA Intel HDMI',
+        ],
+        1 => [
+            'number' => '1',
+            'card' => 'HDA-Intel - HDA Intel PCH',
+        ],
+    ], self::$parser->getSoundCards());
   }
 
   /**
@@ -91,18 +94,18 @@ class LinuxGenericDistroTest extends PHPUnit_Framework_TestCase
    */
   public static function checkCPU()
   {
-      self::assertEquals(array(
-      array(
-        'Vendor' => 'GenuineIntel',
-        'Model' => 'Intel(R) Pentium(R) CPU G3420 @ 3.20GHz',
-        'MHz' => '1000.000',
-      ),
-      array(
-        'Model' => 'Intel(R) Pentium(R) CPU G3420 @ 3.20GHz',
-        'Vendor' => 'GenuineIntel',
-        'MHz' => '3200.000',
-      ),
-    ), self::$parser->getCPU());
+    self::assertEquals([
+        [
+            'Vendor' => 'GenuineIntel',
+            'Model' => 'Intel(R) Pentium(R) CPU G3420 @ 3.20GHz',
+            'MHz' => '1000.000',
+        ],
+        [
+            'Model' => 'Intel(R) Pentium(R) CPU G3420 @ 3.20GHz',
+            'Vendor' => 'GenuineIntel',
+            'MHz' => '3200.000',
+        ],
+    ], self::$parser->getCPU());
   }
 
   /**
@@ -110,114 +113,114 @@ class LinuxGenericDistroTest extends PHPUnit_Framework_TestCase
    */
   public static function checkMdadm()
   {
-      self::assertEquals(array(0 => array(
-        'device' => '/dev/md1',
-        'status' => 'active',
-        'level' => '1',
-        'drives' => array(
-          0 => array(
-            'drive' => '/dev/sdb2',
-            'state' => 'normal',
-          ),
-          1 => array(
-            'drive' => '/dev/sdc2',
-            'state' => 'normal',
-          ),
-        ),
-        'size' => '931.02 GiB',
-        'count' => '2/2',
-        'chart' => 'UU',
-      ),
-      1 => array(
-        'device' => '/dev/md0',
-        'status' => 'active',
-        'level' => '1',
-        'drives' => array(
-          0 => array(
-            'drive' => '/dev/sdb1',
-            'state' => 'normal',
-          ),
-          1 => array(
-            'drive' => '/dev/sdc1',
-            'state' => 'normal',
-          ),
-        ),
-        'size' => '499.94 MiB',
-        'count' => '2/2',
-        'chart' => 'UU',
-      ),
-      2 => array(
-        'device' => '/dev/md2',
-        'status' => 'active',
-        'level' => '10',
-        'drives' => array(
-          0 => array(
-            'drive' => '/dev/sda2',
-            'state' => 'normal',
-          ),
-          1 => array(
-            'drive' => '/dev/sdc2',
-            'state' => 'normal',
-          ),
-          2 => array(
-            'drive' => '/dev/sdd2',
-            'state' => 'normal',
-          ),
-          3 => array(
-            'drive' => '/dev/sdb2',
-            'state' => 'normal',
-          ),
-        ),
-        'size' => '129.28 GiB',
-        'count' => '4/4',
-        'chart' => 'UUUU',
-      ),
-      3 => array(
-        'device' => '/dev/md3',
-        'status' => 'active',
-        'level' => '6',
-        'drives' => array(
-          0 => array(
-            'drive' => '/dev/sdh',
-            'state' => 'normal',
-          ),
-          1 => array(
-            'drive' => '/dev/sde',
-            'state' => 'normal',
-          ),
-          2 => array(
-            'drive' => '/dev/sdg',
-            'state' => 'normal',
-          ),
-          3 => array(
-            'drive' => '/dev/sdf',
-            'state' => 'normal',
-          ),
-          4 => array(
-            'drive' => '/dev/sdd',
-            'state' => 'normal',
-          ),
-          5 => array(
-            'drive' => '/dev/sdb',
-            'state' => 'normal',
-          ),
-          6 => array(
-            'drive' => '/dev/sdc',
-            'state' => 'normal',
-          ),
-        ),
-        'size' => '341.83 GiB',
-        'count' => '7/7',
-        'chart' => 'UUUUUUU',
-      ),
-    ), self::$parser->getRAID());
+    self::assertEquals([
+        0 => [
+            'device' => '/dev/md1',
+            'status' => 'active',
+            'level' => '1',
+            'drives' => [
+                0 => [
+                    'drive' => '/dev/sdb2',
+                    'state' => 'normal',
+                ],
+                1 => [
+                    'drive' => '/dev/sdc2',
+                    'state' => 'normal',
+                ],
+            ],
+            'size' => '931.02 GiB',
+            'count' => '2/2',
+            'chart' => 'UU',
+        ],
+        1 => [
+            'device' => '/dev/md0',
+            'status' => 'active',
+            'level' => '1',
+            'drives' => [
+                0 => [
+                    'drive' => '/dev/sdb1',
+                    'state' => 'normal',
+                ],
+                1 => [
+                    'drive' => '/dev/sdc1',
+                    'state' => 'normal',
+                ],
+            ],
+            'size' => '499.94 MiB',
+            'count' => '2/2',
+            'chart' => 'UU',
+        ],
+        2 => [
+            'device' => '/dev/md2',
+            'status' => 'active',
+            'level' => '10',
+            'drives' => [
+                0 => [
+                    'drive' => '/dev/sda2',
+                    'state' => 'normal',
+                ],
+                1 => [
+                    'drive' => '/dev/sdc2',
+                    'state' => 'normal',
+                ],
+                2 => [
+                    'drive' => '/dev/sdd2',
+                    'state' => 'normal',
+                ],
+                3 => [
+                    'drive' => '/dev/sdb2',
+                    'state' => 'normal',
+                ],
+            ],
+            'size' => '129.28 GiB',
+            'count' => '4/4',
+            'chart' => 'UUUU',
+        ],
+        3 => [
+            'device' => '/dev/md3',
+            'status' => 'active',
+            'level' => '6',
+            'drives' => [
+                0 => [
+                    'drive' => '/dev/sdh',
+                    'state' => 'normal',
+                ],
+                1 => [
+                    'drive' => '/dev/sde',
+                    'state' => 'normal',
+                ],
+                2 => [
+                    'drive' => '/dev/sdg',
+                    'state' => 'normal',
+                ],
+                3 => [
+                    'drive' => '/dev/sdf',
+                    'state' => 'normal',
+                ],
+                4 => [
+                    'drive' => '/dev/sdd',
+                    'state' => 'normal',
+                ],
+                5 => [
+                    'drive' => '/dev/sdb',
+                    'state' => 'normal',
+                ],
+                6 => [
+                    'drive' => '/dev/sdc',
+                    'state' => 'normal',
+                ],
+            ],
+            'size' => '341.83 GiB',
+            'count' => '7/7',
+            'chart' => 'UUUUUUU',
+        ],
+    ], self::$parser->getRAID());
   }
 
-    public static function tearDownAfterClass()
-    {
-        self::$parser = null;
-        Common::unconfig();
-        Common::$path_prefix = false;
-    }
-}
+  public static function tearDownAfterClass()
+  {
+    self::$parser = null;
+    Common::unconfig();
+    Common::$path_prefix = false;
+  }
 }

--- a/tests/os/Linux/Linux.php
+++ b/tests/os/Linux/Linux.php
@@ -3,37 +3,40 @@
 use \Linfo\Common;
 use \Linfo\Linfo;
 
-if (PHP_OS == 'Linux') {
 
 /*
  * Primarily validate return types
  */
 class LinuxTest extends PHPUnit_Framework_TestCase
 {
-    protected static $parser;
+  protected static $parser;
 
-    public static function setUpBeforeClass()
-    {
-        $linfo = new Linfo();
-        self::$parser = $linfo->getParser();
-
-        self::assertInstanceOf('\\Linfo\\OS\\Linux', self::$parser);
-
-        self::$parser->determineCPUPercentage();
+  public static function setUpBeforeClass()
+  {
+    if (PHP_OS !== 'Linux') {
+      self::markTestSkipped('Skip tests for Linux on other os');
     }
 
-    public static function tearDownAfterClass()
-    {
-        self::$parser = null;
-        Common::unconfig();
-    }
+    $linfo = new Linfo();
+    self::$parser = $linfo->getParser();
+
+    self::assertInstanceOf('\\Linfo\\OS\\Linux', self::$parser);
+
+    self::$parser->determineCPUPercentage();
+  }
+
+  public static function tearDownAfterClass()
+  {
+    self::$parser = null;
+    Common::unconfig();
+  }
 
   /**
    * @test
    */
   public static function getOS()
   {
-      self::assertEquals('Linux', self::$parser->getOS());
+    self::assertEquals('Linux', self::$parser->getOS());
   }
 
   /**
@@ -41,7 +44,7 @@ class LinuxTest extends PHPUnit_Framework_TestCase
    */
   public static function getKernel()
   {
-      self::assertInternalType('string', self::$parser->getKernel());
+    self::assertInternalType('string', self::$parser->getKernel());
   }
 
   /**
@@ -49,7 +52,7 @@ class LinuxTest extends PHPUnit_Framework_TestCase
    */
   public static function getHostname()
   {
-      self::assertInternalType('string', self::$parser->getHostname());
+    self::assertInternalType('string', self::$parser->getHostname());
   }
 
   /**
@@ -57,7 +60,7 @@ class LinuxTest extends PHPUnit_Framework_TestCase
    */
   public static function getCPUArchitecture()
   {
-      self::assertInternalType('string', self::$parser->getCPUArchitecture());
+    self::assertInternalType('string', self::$parser->getCPUArchitecture());
   }
 
   /**
@@ -65,7 +68,7 @@ class LinuxTest extends PHPUnit_Framework_TestCase
    */
   public static function getTemps()
   {
-      self::assertInternalType('array', self::$parser->getTemps());
+    self::assertInternalType('array', self::$parser->getTemps());
   }
 
   /**
@@ -73,7 +76,7 @@ class LinuxTest extends PHPUnit_Framework_TestCase
    */
   public static function getRAID()
   {
-      self::assertInternalType('array', self::$parser->getRAID());
+    self::assertInternalType('array', self::$parser->getRAID());
   }
 
   /**
@@ -81,11 +84,11 @@ class LinuxTest extends PHPUnit_Framework_TestCase
    */
   public static function getDistro()
   {
-      $distro = self::$parser->getDistro();
-      self::assertInternalType('array', $distro);
-      foreach (array('name', 'version') as $key) {
-          self::assertArrayHasKey($key, $distro);
-      }
+    $distro = self::$parser->getDistro();
+    self::assertInternalType('array', $distro);
+    foreach (['name', 'version'] as $key) {
+      self::assertArrayHasKey($key, $distro);
+    }
   }
 
   /**
@@ -93,7 +96,7 @@ class LinuxTest extends PHPUnit_Framework_TestCase
    */
   public static function getNumLoggedIn()
   {
-      self::assertInternalType('int', self::$parser->getNumLoggedIn());
+    self::assertInternalType('int', self::$parser->getNumLoggedIn());
   }
 
   /**
@@ -101,7 +104,7 @@ class LinuxTest extends PHPUnit_Framework_TestCase
    */
   public static function getCPUUsage()
   {
-      self::assertInternalType('float', self::$parser->getCPUUsage());
+    self::assertInternalType('float', self::$parser->getCPUUsage());
   }
 
   /**
@@ -109,12 +112,12 @@ class LinuxTest extends PHPUnit_Framework_TestCase
    */
   public static function getSoundCards()
   {
-      $cards = self::$parser->getSoundCards();
-      self::assertInternalType('array', $cards);
-      foreach ($cards as $card) {
-          self::assertArrayHasKey('card', $card);
-          self::assertArrayHasKey('number', $card);
-      }
+    $cards = self::$parser->getSoundCards();
+    self::assertInternalType('array', $cards);
+    foreach ($cards as $card) {
+      self::assertArrayHasKey('card', $card);
+      self::assertArrayHasKey('number', $card);
+    }
   }
 
   /**
@@ -122,17 +125,27 @@ class LinuxTest extends PHPUnit_Framework_TestCase
    */
   public static function getMounts()
   {
-      $mounts = self::$parser->getMounts();
-      self::assertInternalType('array', $mounts);
-      foreach ($mounts as $mount) {
-          foreach (array('device', 'mount', 'type', 'size', 'used', 'free', 'free_percent', 'used_percent', 'options') as $key) {
-              self::assertArrayHasKey($key, $mount);
-          }
-          self::assertInternalType('string', $mount['device']);
-          self::assertInternalType('string', $mount['mount']);
-          self::assertInternalType('string', $mount['type']);
-          self::assertInternalType('array', $mount['options']);
+    $mounts = self::$parser->getMounts();
+    self::assertInternalType('array', $mounts);
+    foreach ($mounts as $mount) {
+      foreach ([
+                   'device',
+                   'mount',
+                   'type',
+                   'size',
+                   'used',
+                   'free',
+                   'free_percent',
+                   'used_percent',
+                   'options'
+               ] as $key) {
+        self::assertArrayHasKey($key, $mount);
       }
+      self::assertInternalType('string', $mount['device']);
+      self::assertInternalType('string', $mount['mount']);
+      self::assertInternalType('string', $mount['type']);
+      self::assertInternalType('array', $mount['options']);
+    }
   }
 
   /**
@@ -140,23 +153,23 @@ class LinuxTest extends PHPUnit_Framework_TestCase
    */
   public static function getNet()
   {
-      $nics = self::$parser->getNet();
-      self::assertInternalType('array', $nics);
-      foreach ($nics as $nic) {
-          foreach (array('sent', 'recieved', 'state', 'type') as $key) {
-              self::assertArrayHasKey($key, $nic);
-          }
-          self::assertInternalType('string', $nic['state']);
-          self::assertInternalType('string', $nic['type']);
-          self::assertInternalType('array', $nic['sent']);
-          self::assertInternalType('array', $nic['recieved']);
-          foreach (array('bytes', 'errors', 'packets') as $key) {
-              self::assertArrayHasKey($key, $nic['sent']);
-              self::assertArrayHasKey($key, $nic['recieved']);
-              self::assertTrue(is_numeric($nic['sent'][$key]));
-              self::assertTrue(is_numeric($nic['recieved'][$key]));
-          }
+    $nics = self::$parser->getNet();
+    self::assertInternalType('array', $nics);
+    foreach ($nics as $nic) {
+      foreach (['sent', 'recieved', 'state', 'type'] as $key) {
+        self::assertArrayHasKey($key, $nic);
       }
+      self::assertInternalType('string', $nic['state']);
+      self::assertInternalType('string', $nic['type']);
+      self::assertInternalType('array', $nic['sent']);
+      self::assertInternalType('array', $nic['recieved']);
+      foreach (['bytes', 'errors', 'packets'] as $key) {
+        self::assertArrayHasKey($key, $nic['sent']);
+        self::assertArrayHasKey($key, $nic['recieved']);
+        self::assertTrue(is_numeric($nic['sent'][$key]));
+        self::assertTrue(is_numeric($nic['recieved'][$key]));
+      }
+    }
   }
 
   /**
@@ -164,7 +177,7 @@ class LinuxTest extends PHPUnit_Framework_TestCase
    */
   public static function getCPU()
   {
-      // TODO: flesh this out
+    // TODO: flesh this out
     self::assertInternalType('array', self::$parser->getCPU());
   }
 
@@ -173,22 +186,22 @@ class LinuxTest extends PHPUnit_Framework_TestCase
    */
   public static function getHD()
   {
-      $drives = self::$parser->getHD();
-      self::assertInternalType('array', $drives);
-      foreach ($drives as $drive) {
-          foreach (array('name', 'vendor', 'device', 'reads', 'writes', 'size', 'partitions') as $key) {
-              self::assertArrayHasKey($key, $drive);
-          }
-          if (is_array($drive['partitions'])) {
-              foreach ($drive['partitions'] as $partition) {
-                  self::assertArrayHasKey('size', $partition);
-                  self::assertArrayHasKey('number', $partition);
-                  self::assertInternalType('int', $partition['size']);
-                  self::assertTrue(is_numeric($partition['number']));
-              }
-          }
-          self::assertInternalType('int', $drive['size']);
+    $drives = self::$parser->getHD();
+    self::assertInternalType('array', $drives);
+    foreach ($drives as $drive) {
+      foreach (['name', 'vendor', 'device', 'reads', 'writes', 'size', 'partitions'] as $key) {
+        self::assertArrayHasKey($key, $drive);
       }
+      if (is_array($drive['partitions'])) {
+        foreach ($drive['partitions'] as $partition) {
+          self::assertArrayHasKey('size', $partition);
+          self::assertArrayHasKey('number', $partition);
+          self::assertInternalType('int', $partition['size']);
+          self::assertTrue(is_numeric($partition['number']));
+        }
+      }
+      self::assertInternalType('int', $drive['size']);
+    }
   }
 
   /**
@@ -196,7 +209,7 @@ class LinuxTest extends PHPUnit_Framework_TestCase
    */
   public static function getUpTime()
   {
-      self::assertInternalType('array', self::$parser->getUpTime());
+    self::assertInternalType('array', self::$parser->getUpTime());
   }
 
   /**
@@ -204,11 +217,11 @@ class LinuxTest extends PHPUnit_Framework_TestCase
    */
   public static function getLoad()
   {
-      $load = self::$parser->getLoad();
-      self::assertInternalType('array', $load);
-      foreach (array('now', '5min', '15min') as $key) {
-          self::assertArrayHasKey($key, $load);
-      }
+    $load = self::$parser->getLoad();
+    self::assertInternalType('array', $load);
+    foreach (['now', '5min', '15min'] as $key) {
+      self::assertArrayHasKey($key, $load);
+    }
   }
 
   /**
@@ -216,17 +229,17 @@ class LinuxTest extends PHPUnit_Framework_TestCase
    */
   public static function getProcessStats()
   {
-      $stats = self::$parser->getProcessStats();
-      self::assertInternalType('array', $stats);
-      foreach (array('totals', 'proc_total', 'threads') as $key) {
-          self::assertArrayHasKey($key, $stats);
-      }
-      self::assertInternalType('int', $stats['proc_total']);
-      self::assertInternalType('int', $stats['threads']);
-      foreach (array('running', 'zombie', 'stopped', 'sleeping') as $key) {
-          self::assertArrayHasKey($key, $stats['totals']);
-          self::assertInternalType('int', $stats['totals'][$key]);
-      }
+    $stats = self::$parser->getProcessStats();
+    self::assertInternalType('array', $stats);
+    foreach (['totals', 'proc_total', 'threads'] as $key) {
+      self::assertArrayHasKey($key, $stats);
+    }
+    self::assertInternalType('int', $stats['proc_total']);
+    self::assertInternalType('int', $stats['threads']);
+    foreach (['running', 'zombie', 'stopped', 'sleeping'] as $key) {
+      self::assertArrayHasKey($key, $stats['totals']);
+      self::assertInternalType('int', $stats['totals'][$key]);
+    }
   }
 
   /**
@@ -234,11 +247,10 @@ class LinuxTest extends PHPUnit_Framework_TestCase
    */
   public static function getRam()
   {
-      $stats = self::$parser->getRam();
-      self::assertInternalType('array', $stats);
-      foreach (array('total', 'type', 'free', 'swapTotal', 'swapFree', 'swapInfo') as $key) {
-          self::assertArrayHasKey($key, $stats);
-      }
+    $stats = self::$parser->getRam();
+    self::assertInternalType('array', $stats);
+    foreach (['total', 'type', 'free', 'swapTotal', 'swapFree', 'swapInfo'] as $key) {
+      self::assertArrayHasKey($key, $stats);
+    }
   }
-}
 }

--- a/tests/os/Linux/Linux.php
+++ b/tests/os/Linux/Linux.php
@@ -166,8 +166,8 @@ class LinuxTest extends PHPUnit_Framework_TestCase
       foreach (['bytes', 'errors', 'packets'] as $key) {
         self::assertArrayHasKey($key, $nic['sent']);
         self::assertArrayHasKey($key, $nic['recieved']);
-        self::assertTrue(is_numeric($nic['sent'][$key]));
-        self::assertTrue(is_numeric($nic['recieved'][$key]));
+        self::assertInternalType('numeric', $nic['sent'][$key]);
+        self::assertInternalType('numeric', $nic['recieved'][$key]);
       }
     }
   }
@@ -197,7 +197,7 @@ class LinuxTest extends PHPUnit_Framework_TestCase
           self::assertArrayHasKey('size', $partition);
           self::assertArrayHasKey('number', $partition);
           self::assertInternalType('int', $partition['size']);
-          self::assertTrue(is_numeric($partition['number']));
+          self::assertInternalType('numeric', $partition['number']);
         }
       }
       self::assertInternalType('int', $drive['size']);

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,16 +1,16 @@
 <phpunit
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
-  backupGlobals="false"
-  backupStaticAttributes="false"
-  bootstrap="bootstrap.php"
-  colors="true">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.8/phpunit.xsd"
+    backupGlobals="false"
+    backupStaticAttributes="false"
+    bootstrap="bootstrap.php"
+    colors="true">
 
   <testsuites>
 
     <!-- Run everything except OS dependent tests -->
     <testsuite name="Linfo">
-    <directory suffix=".php">linfo/</directory>
+      <directory suffix=".php">linfo/</directory>
     </testsuite>
 
     <testsuite name="Linux">

--- a/tests/test_lang.php
+++ b/tests/test_lang.php
@@ -1,3 +1,3 @@
 <?php
 
-return require dirname(dirname(__FILE__)).'/src/Linfo/Lang/en.php';
+return require dirname(dirname(__FILE__)) . '/src/Linfo/Lang/en.php';


### PR DESCRIPTION
- Require at least php5.4 ([] ist not working with php < 5.4)
- Replace tabs with 2 spaces
- Set markTestSkipped in setUpBeforeClass for excluding tests when operating system does not match instead of if around test-class
- Migrate files in test to short-array
- Add link to travis build to travis badge