### PR TITLE
Fix wrong assignment

### DIFF
--- a/src/Linfo/OS/Linux.php
+++ b/src/Linfo/OS/Linux.php
@@ -918,7 +918,7 @@ class Linux extends Unixcommon
                 break;
             }
 
-            if ($state = 'unknown' && file_exists($path.'/carrier')) {
+            if ($state === 'unknown' && file_exists($path.'/carrier')) {
                 $carrier = Common::getContents($path.'/carrier', false);
                 if (!empty($carrier)) {
                     $state = 'up';


### PR DESCRIPTION
I guess `$state = 'unknown'` is wrong in this case. Given that `$operstate_contents` is 'up' there is no need to fetch status from carrier. 