### PR TITLE
Fix PHP8 TypeError

### DIFF
--- a/src/Linfo/OS/Linux.php
+++ b/src/Linfo/OS/Linux.php
@@ -334,10 +334,10 @@ class Linux extends Unixcommon
         }
 
         // Seconds
-        list($seconds) = explode(' ', $contents, 1);
+        list($seconds,) = explode(' ', $contents);
 
         // Get it textual, as in days/minutes/hours/etc
-        $uptime = Common::secondsConvert(ceil($seconds));
+        $uptime = Common::secondsConvert(ceil((float)$seconds));
 
         // Now find out when the system was booted
         $contents = Common::getContents('/proc/stat', false);


### PR DESCRIPTION
Also fixes an old explode usage bug.

$contents is a string like `'1304629.08 5049272.72'`
`explode(' ', $contents, 1);`
 will return `['1304629.08 5049272.72']` 
because the third arg `limit` forces the returned array to contain a maximum of 1 element with the last element containing the rest of string.