### PR TITLE
Handle missing CPU clockrate

### DIFF
--- a/src/Linfo/OS/FreeBSD.php
+++ b/src/Linfo/OS/FreeBSD.php
@@ -470,7 +470,7 @@ class FreeBSD extends BSDcommon
             // Save each
             $cpus[] = array(
                 'Model' => $this->sysctl['hw.model'],
-                'MHz' => (int) trim($this->sysctl['hw.clockrate']),
+                'MHz' => (int) trim($this->sysctl['hw.clockrate'] ?? "0"),
             );
         }
 


### PR DESCRIPTION
Hi there! Me again! Now with a FreeBSD on ARM64 issue...

FreeBSD on ARM64 is missing a hw.clockrate value.  And the
cpufreq(4) interface doesn't seem to provide one either.
This provides a 0 value when this field is missing instead
of throwing an exception.