### PR TITLE
parse_ini_file if the file is readable

### DIFF
--- a/src/Linfo/OS/Linux.php
+++ b/src/Linfo/OS/Linux.php
@@ -957,8 +957,18 @@ class Linux extends Unixcommon
             if (!$type) {
                 $type_contents = strtoupper(Common::getContents($path.'/device/modalias'));
                 list($type_match) = explode(':', $type_contents, 2);
-                $uevent_contents = @parse_ini_file($path.'/uevent');
-                $device_uevent_contents = @parse_ini_file($path.'/device/uevent');
+		    
+		if(is_readable($path.'/uevent')){
+                    $uevent_contents = @parse_ini_file($path.'/uevent');
+                } else{
+                    $uevent_contents = false;
+                }
+
+                if(is_readable($path.'/device/uevent')){
+                    $device_uevent_contents = @parse_ini_file($path.'/device/uevent');
+                } else{
+                    $device_uevent_contents = false;
+                }
 
                 if ($uevent_contents != false && isset($uevent_contents['DEVTYPE'])) {
                   $type = ucfirst($uevent_contents['DEVTYPE']);


### PR DESCRIPTION
This is the problem fixed in this patch:
Warning: parse_ini_file(/sys/class/net/br-9fc543d48492/device/uevent): Failed to open stream: No such file or directory in ./vendor/linfo/linfo/src/Linfo/OS/Linux.php on line 972 (error level: 2) Warning: parse_ini_file(/sys/class/net/br-33ac76a12cae/device/uevent): Failed to open stream: No such file or directory in /vendor/linfo/linfo/src/Linfo/OS/Linux.php on line 972 (error level: 2) Warning: parse_ini_file(/sys/class/net/docker0/device/uevent): Failed to open stream: No such file or directory in /vendor/linfo/linfo/src/Linfo/OS/Linux.php on line 972 (error level: 2) Warning: parse_ini_file(/sys/class/net/virbr0/device/uevent): Failed to open stream: No such file or directory in /vendor/linfo/linfo/src/Linfo/OS/Linux.php on line 972 (error level: 2)